### PR TITLE
fix: unintended restart of VSI

### DIFF
--- a/server/datadisk/datadisk.go
+++ b/server/datadisk/datadisk.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/onprem"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/common"
-	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/lock"
 )
 
 func CreatePingRoute(version, compileTime string) gin.HandlerFunc {
@@ -37,11 +36,6 @@ func CreatePingRoute(version, compileTime string) gin.HandlerFunc {
 
 // syncDataDisk is invoked to synchronize the state of our resource
 func syncDataDisk(req map[string]any) common.Action {
-	// just a poor man's solution for now
-	if !lock.Lock.TryLock() {
-		return common.CreateStatusAction(common.Waiting)
-	}
-	defer lock.Lock.Unlock()
 	// assemble all information about the environment by merging the config maps
 	env := common.EnvFromConfigMapsOrSecrets(req)
 
@@ -65,10 +59,6 @@ func syncDataDisk(req map[string]any) common.Action {
 }
 
 func finalizeDataDisk(req map[string]any) common.Action {
-	if !lock.Lock.TryLock() {
-		return common.CreateStatusAction(common.Waiting)
-	}
-	defer lock.Lock.Unlock()
 
 	env := common.EnvFromConfigMapsOrSecrets(req)
 

--- a/server/datadiskref/datadisk.go
+++ b/server/datadiskref/datadisk.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/onprem"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/common"
-	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/lock"
 )
 
 func CreatePingRoute(version, compileTime string) gin.HandlerFunc {
@@ -37,11 +36,6 @@ func CreatePingRoute(version, compileTime string) gin.HandlerFunc {
 
 // syncDataDisk is invoked to synchronize the state of our resource
 func syncDataDisk(req map[string]any) common.Action {
-	// just a poor man's solution for now
-	if !lock.Lock.TryLock() {
-		return common.CreateStatusAction(common.Waiting)
-	}
-	defer lock.Lock.Unlock()
 	// assemble all information about the environment by merging the config maps
 	env := common.EnvFromConfigMapsOrSecrets(req)
 


### PR DESCRIPTION
Fixes https://github.com/ibm-hyper-protect/k8s-operator-hpcr/issues/79

The root cause of restarting the VSI is that the handler looking for the data disk considers the disk as temporarily unavailable. This results in a changed config of the VSI, so it restarts.
The unavailability of the data disk in turn is caused by the data disk handler running into a lock. I had introduced this lock initially to prevent the very slow handlers for onprem VSIs to lock against each other, so a refresh operation would not interfer with the main operation. 
However the data disk operations are very fast and there is no reason to lock, in particular not using the same lock as for the VSI resource. 
I consider it safe to remove the lock, this will resolve the issue.