### PR TITLE
fix: add more logging

### DIFF
--- a/common/logging.go
+++ b/common/logging.go
@@ -1,0 +1,35 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package common
+
+import (
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+var count uint64
+
+// EntryExit immediately prints an entry statement and returns a function that can be used with defer and that prints an exit statement with timing
+func EntryExit(method string) func() {
+	tEnter := time.Now()
+	idx := atomic.AddUint64(&count, 1)
+	log.Printf("Enter [%d]: %s", idx, method)
+
+	return func() {
+		tExit := time.Now()
+		log.Printf("Exit  [%d]: %s in [%s]", idx, method, tExit.Sub(tEnter))
+	}
+}

--- a/common/logging_test.go
+++ b/common/logging_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package common
+
+import (
+	"testing"
+	"time"
+)
+
+func doSomething() {
+	defer EntryExit("doSomething")()
+	time.Sleep(time.Second)
+}
+
+func TestLogging(t *testing.T) {
+	doSomething()
+}

--- a/onprem/constants.go
+++ b/onprem/constants.go
@@ -33,4 +33,6 @@ const (
 	ResourceNameDataDiskRefs = "onprem-datadiskrefs"
 	ResourceNameNetworkRefs  = "onprem-networkrefs"
 	ResourceNameVSIs         = "onprem-hpcrs"
+
+	NeedResults = int32(1)
 )

--- a/onprem/domain.go
+++ b/onprem/domain.go
@@ -23,6 +23,7 @@ import (
 
 	libvirt "github.com/digitalocean/go-libvirt"
 	"github.com/google/uuid"
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	"libvirt.org/go/libvirtxml"
 )
 
@@ -271,6 +272,8 @@ func DeleteDomainByName(client *LivirtClient) func(name string) error {
 	delDomain := deleteDomain(client)
 
 	return func(name string) error {
+		// log this config
+		defer CM.EntryExit(fmt.Sprintf("DeleteDomainByName(%s)", name))()
 		// log this
 		log.Printf("Deleting domain by name [%s] ...", name)
 		// locate the domain

--- a/onprem/instance.go
+++ b/onprem/instance.go
@@ -25,6 +25,7 @@ import (
 	"crypto/sha256"
 
 	"github.com/digitalocean/go-libvirt"
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	A "github.com/ibm-hyper-protect/terraform-provider-hpcr/fp/array"
 	"libvirt.org/go/libvirtxml"
 )
@@ -226,6 +227,8 @@ func CreateInstanceSync(client *LivirtClient) func(opt *InstanceOptions) (*libvi
 	createNetworksXML := CreateNetworksXML()
 
 	return func(opt *InstanceOptions) (*libvirtxml.Domain, error) {
+		// log this config
+		defer CM.EntryExit(fmt.Sprintf("CreateInstanceSync(%s)", opt.Name))()
 		// prepare some names
 		name := opt.Name
 		cidataName := GetCIDataVolumeName(name)
@@ -331,6 +334,8 @@ func DeleteInstanceSync(client *LivirtClient) func(storagePool, name string) err
 
 	// delete the disks, but failure will only be logged
 	delDisks := func(storagePool, name string) {
+		// log this config
+		defer CM.EntryExit(fmt.Sprintf("DeleteInstanceSync(%s, %s)", storagePool, name))()
 		// access the pool
 		pool, err := conn.StoragePoolLookupByName(storagePool)
 		if err != nil {

--- a/onprem/logging.go
+++ b/onprem/logging.go
@@ -16,8 +16,10 @@ package onprem
 
 import (
 	"bytes"
+	"fmt"
 	"regexp"
 
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	"libvirt.org/go/libvirtxml"
 )
 
@@ -94,6 +96,7 @@ func GetLoggingVolume(client *LivirtClient) func(storagePool, name string) (stri
 	conn := client.LibVirt
 
 	return func(storagePool, name string) (string, error) {
+		defer CM.EntryExit(fmt.Sprintf("GetLoggingVolume(%s, %s)", storagePool, name))()
 		// access the pool
 		pool, err := conn.StoragePoolLookupByName(storagePool)
 		if err != nil {

--- a/onprem/network.go
+++ b/onprem/network.go
@@ -19,9 +19,9 @@ import (
 	"encoding/xml"
 	"fmt"
 	"log"
-	"math"
 
 	libvirt "github.com/digitalocean/go-libvirt"
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/common"
 	A "github.com/ibm-hyper-protect/terraform-provider-hpcr/fp/array"
 	"libvirt.org/go/libvirtxml"
@@ -55,14 +55,17 @@ func GetDCHPLeases(client *LivirtClient) func(networkName string) ([]libvirt.Net
 	conn := client.LibVirt
 
 	return func(networkName string) ([]libvirt.NetworkDhcpLease, error) {
+		defer CM.EntryExit(fmt.Sprintf("GetDCHPLeases(%s)", networkName))()
 
+		log.Printf("NetworkLookupByName: %s", networkName)
 		network, err := conn.NetworkLookupByName(networkName)
 		if err != nil {
 			log.Printf("Unable to lookup the network [%s], cause: [%v]", networkName, err)
 			return nil, err
 		}
 
-		leases, ret, err := conn.NetworkGetDhcpLeases(network, nil, math.MaxInt32, 0)
+		log.Printf("NetworkGetDhcpLeases: %s", network.Name)
+		leases, ret, err := conn.NetworkGetDhcpLeases(network, nil, NeedResults, 0)
 		if err != nil {
 			log.Printf("Unable to get leases for the network [%s], ret: [%d], cause: [%v]", networkName, ret, err)
 			return nil, err

--- a/onprem/volume.go
+++ b/onprem/volume.go
@@ -19,6 +19,7 @@ import (
 	"log"
 
 	libvirt "github.com/digitalocean/go-libvirt"
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	"libvirt.org/go/libvirtxml"
 )
 
@@ -41,6 +42,8 @@ func createDefaultVolume() libvirtxml.StorageVolume {
 
 func deleteStorageVol(conn *libvirt.Libvirt) func(pool libvirt.StoragePool, name string) (*libvirt.StorageVol, error) {
 	return func(pool libvirt.StoragePool, name string) (*libvirt.StorageVol, error) {
+		// log this config
+		defer CM.EntryExit(fmt.Sprintf("deleteStorageVol(%s, %s)", pool.Name, name))()
 		existing, err := conn.StorageVolLookupByName(pool, name)
 		if err != nil {
 			return nil, err

--- a/server/datadisk/datadisk.go
+++ b/server/datadisk/datadisk.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/onprem"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/common"
 )
@@ -84,6 +85,9 @@ func finalizeDataDisk(req map[string]any) (*common.ResourceStatus, error) {
 func CreateControllerSyncRoute() gin.HandlerFunc {
 
 	return func(c *gin.Context) {
+		// log this config
+		defer CM.EntryExit("DataDiskCreateControllerSyncRoute")()
+
 		log.Printf("synchronizing data disk ...")
 		jsonData, err := io.ReadAll(c.Request.Body)
 		if err != nil {
@@ -127,6 +131,10 @@ func CreateControllerSyncRoute() gin.HandlerFunc {
 
 func CreateControllerFinalizeRoute() gin.HandlerFunc {
 	return func(c *gin.Context) {
+
+		// log this config
+		defer CM.EntryExit("DataDiskCreateControllerFinalizeRoute")()
+
 		log.Printf("finalizing ...")
 
 		jsonData, err := io.ReadAll(c.Request.Body)
@@ -174,6 +182,8 @@ func CreateControllerFinalizeRoute() gin.HandlerFunc {
 // CreateControllerCustomizeRoute is invoked to
 func CreateControllerCustomizeRoute() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// log this config
+		defer CM.EntryExit("DataDiskCreateControllerCustomizeRoute")()
 		// parse body
 		jsonData, err := io.ReadAll(c.Request.Body)
 		if err != nil {

--- a/server/datadiskref/datadisk.go
+++ b/server/datadiskref/datadisk.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/onprem"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/common"
 )
@@ -61,6 +62,9 @@ func syncDataDisk(req map[string]any) (*common.ResourceStatus, error) {
 func CreateControllerSyncRoute() gin.HandlerFunc {
 
 	return func(c *gin.Context) {
+		// log this config
+		defer CM.EntryExit("DataDiskRefCreateControllerSyncRoute")()
+
 		log.Printf("synchronizing data disk ref...")
 		jsonData, err := io.ReadAll(c.Request.Body)
 		if err != nil {
@@ -105,6 +109,8 @@ func CreateControllerSyncRoute() gin.HandlerFunc {
 // CreateControllerCustomizeRoute is invoked to
 func CreateControllerCustomizeRoute() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// log this config
+		defer CM.EntryExit("DataDiskRefCreateControllerCustomizeRoute")()
 		// parse body
 		jsonData, err := io.ReadAll(c.Request.Body)
 		if err != nil {

--- a/server/onprem/actions.go
+++ b/server/onprem/actions.go
@@ -15,10 +15,12 @@
 package onprem
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
 	"github.com/digitalocean/go-libvirt"
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/onprem"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/common"
 	C "github.com/ibm-hyper-protect/terraform-provider-hpcr/contract"
@@ -37,12 +39,15 @@ func getIPAddress(lease libvirt.NetworkDhcpLease) string {
 
 func createInstanceRunningAction(client *onprem.LivirtClient, inst *libvirtxml.Domain, opt *onprem.InstanceOptions) (*common.ResourceStatus, error) {
 
+	defer CM.EntryExit(fmt.Sprintf("createInstanceRunningAction(%s)", opt.Name))()
+
 	getLoggingVolume := onprem.GetLoggingVolume(client)
 	getLeases := onprem.GetDCHPLeases(client)
 
 	// getIPAddresses determines the IP Addresses for the instance by checking for a all leases
 	// for the configured network and then filtering down the list to the hostname
 	getIPAddresses := func() []string {
+		defer CM.EntryExit(fmt.Sprintf("getIPAddresses(%s)", opt.Name))()
 		networks := onprem.GetNetworks(opt)
 		var leases []libvirt.NetworkDhcpLease
 		for _, network := range networks {
@@ -139,8 +144,7 @@ func createInstanceRunningAction(client *onprem.LivirtClient, inst *libvirtxml.D
 // CreateSyncAction synchronizes the state of the resource and determines what to do next
 func CreateSyncAction(client *onprem.LivirtClient, opt *onprem.InstanceOptions) (*common.ResourceStatus, error) {
 	// log this config
-	log.Printf("Entering CreateSyncAction for config [%v]", opt)
-	defer log.Printf("Leaving CreateSyncAction for config [%v]", opt)
+	defer CM.EntryExit(fmt.Sprintf("CreateSyncAction(%s)", opt.Name))()
 	// checks for the validity of the instance
 	isInstanceValid := onprem.IsInstanceValid(client)
 	inst, ok := isInstanceValid(opt)
@@ -167,8 +171,7 @@ func CreateSyncAction(client *onprem.LivirtClient, opt *onprem.InstanceOptions) 
 
 func CreateFinalizeAction(client *onprem.LivirtClient, opt *onprem.InstanceOptions) (*common.ResourceStatus, error) {
 	// log this config
-	log.Printf("Entering CreateFinalizeAction for config [%v]", opt)
-	defer log.Printf("Leaving CreateFinalizeAction for config [%v]", opt)
+	defer CM.EntryExit(fmt.Sprintf("CreateFinalizeAction(%s)", opt.Name))()
 	// TODO proper check for existence comes here
 	// ...
 	// destroy the instance

--- a/server/onprem/onprem.go
+++ b/server/onprem/onprem.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/onprem"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/common"
 	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server/datadisk"
@@ -133,7 +134,9 @@ func finalizeOnPrem(req map[string]any) (*common.ResourceStatus, error) {
 func CreateControllerSyncRoute() gin.HandlerFunc {
 
 	return func(c *gin.Context) {
-		log.Printf("synchronizing onprem VSI ...")
+		// log this config
+		defer CM.EntryExit("OnPremCreateControllerSyncRoute")()
+
 		jsonData, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			// Handle error
@@ -182,7 +185,8 @@ func CreateControllerSyncRoute() gin.HandlerFunc {
 
 func CreateControllerFinalizeRoute() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		log.Printf("finalizing ...")
+		// log this config
+		defer CM.EntryExit("OnPremCreateControllerFinalizeRoute")()
 
 		jsonData, err := io.ReadAll(c.Request.Body)
 		if err != nil {
@@ -229,6 +233,8 @@ func CreateControllerFinalizeRoute() gin.HandlerFunc {
 // CreateControllerCustomizeRoute is invoked to
 func CreateControllerCustomizeRoute() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// log this config
+		defer CM.EntryExit("OnPremCreateControllerCustomizeRoute")()
 		// parse body
 		jsonData, err := io.ReadAll(c.Request.Body)
 		if err != nil {


### PR DESCRIPTION
In a customer scenario the operator can hang. Debugging shows that the `createInstanceRunningAction` method sometimes never returns. This in turn causes a central lock never to be released, so all subsequent operations hang. The operator has to be restarted. 
Why does the `createInstanceRunningAction` method never return? 

This PR add entry/exit logs to the involved functions to be able to tell the reason. 
I am suspecting that the operation that is trying to query the leases for the VSI (and the associated IP address) never returns. Maybe this is caused by an incorrect use of the `NeedResults` parameter in the `NetworkGetDhcpLeases` call. I was not able to find any documentation of this parameter and I suspected it would set the maximum number of expected results, so I set it to `math.MaxInt`. Maybe however this is meant to be just a flag modeled as an `int32`. In this PR I set it to `1` to see if this helps. At the same time I opened a question to the author of the libvirt library: https://github.com/digitalocean/go-libvirt/issues/197

In any case this PR should show what's happening:
- if the code still hangs, we will see what method hangs and then try to figure out why
- if the code does not hang, the `NeedResults` setting was wrong in the first place and then we have at least detailed logs