### PR TITLE
fix: add timeout handling for APIs that seem to hang

### DIFF
--- a/common/timeout.go
+++ b/common/timeout.go
@@ -1,0 +1,35 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+)
+
+// PanicAfterTimeout starts a timer and after a timeout panics and kills the process
+// the timer can be cancelled via the cancel function, e.g. in a defer call
+func PanicAfterTimeout(message string, delay time.Duration) context.CancelFunc {
+	// manage the timeout
+	timer := time.AfterFunc(delay, func() {
+		log.Printf("[%s] did not complete after [%s], killing the process now ...", message, delay)
+		panic(fmt.Sprintf("Timeout for [%s]", message))
+	})
+	return func() {
+		timer.Stop()
+	}
+}

--- a/common/timeout_test.go
+++ b/common/timeout_test.go
@@ -1,0 +1,35 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package common
+
+import (
+	"testing"
+	"time"
+)
+
+func doSomethingLong() {
+	time.Sleep(3 * time.Second)
+}
+
+func doSomethingWithPanic() {
+	defer PanicAfterTimeout("doSomethingWithPanic", 5*time.Second)()
+	doSomethingLong()
+}
+
+func TestTimeout(t *testing.T) {
+	doSomethingWithPanic()
+
+	time.Sleep(10 * time.Second)
+}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/bytedance/sonic v1.9.1 // indirect
+	github.com/bytedance/sonic v1.9.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -90,7 +90,7 @@ require (
 	golang.org/x/sys v0.9.0 // indirect
 	golang.org/x/text v0.10.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
+github.com/bytedance/sonic v1.9.2 h1:GDaNjuWSGu09guE9Oql0MSTNhNCLlWwO8y/xM5BzcbM=
+github.com/bytedance/sonic v1.9.2/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
@@ -162,6 +164,7 @@ github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qri-io/jsonpointer v0.1.1 h1:prVZBZLL6TW5vsSB9fFHFAMBLI4b0ri5vribQlTJiBA=
@@ -169,6 +172,8 @@ github.com/qri-io/jsonpointer v0.1.1/go.mod h1:DnJPaYgiKu56EuDp8TU5wFLdZIcAnb/uH
 github.com/qri-io/jsonschema v0.2.1 h1:NNFoKms+kut6ABPf6xiKNM5214jzxAhDBrPHCJ97Wg0=
 github.com/qri-io/jsonschema v0.2.1/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
@@ -289,6 +294,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/onprem/logging.go
+++ b/onprem/logging.go
@@ -106,7 +106,7 @@ func GetLoggingVolume(client *LivirtClient) func(storagePool, name string) (stri
 		log.Printf("Looking up storage pool [%s] by name ...", name)
 		pool, err := conn.StoragePoolLookupByName(storagePool)
 		if err != nil {
-			log.Printf("Error looking up storage pool [%s] by name, cause: [%v]", name, err)
+			log.Printf("Error looking up storage pool [%s] by name, cause: [%v]", storagePool, err)
 			return "", err
 		}
 		log.Printf("Lookup up of storage pool [%s] was successful.", pool.Name)

--- a/server/onprem/actions.go
+++ b/server/onprem/actions.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/digitalocean/go-libvirt"
 	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
@@ -38,8 +39,10 @@ func getIPAddress(lease libvirt.NetworkDhcpLease) string {
 }
 
 func createInstanceRunningAction(client *onprem.LivirtClient, inst *libvirtxml.Domain, opt *onprem.InstanceOptions) (*common.ResourceStatus, error) {
+	msg := fmt.Sprintf("createInstanceRunningAction(%s)", opt.Name)
 
-	defer CM.EntryExit(fmt.Sprintf("createInstanceRunningAction(%s)", opt.Name))()
+	defer CM.PanicAfterTimeout(msg, 5*time.Second)()
+	defer CM.EntryExit(msg)()
 
 	getLoggingVolume := onprem.GetLoggingVolume(client)
 	getLeases := onprem.GetDCHPLeases(client)
@@ -74,7 +77,7 @@ func createInstanceRunningAction(client *onprem.LivirtClient, inst *libvirtxml.D
 	data, err := getLoggingVolume(opt.StoragePool, logName)
 	if err != nil {
 		// log this
-		log.Printf("Unable to get the logging volumd [%s] from pool [%s], cause: [%v]", logName, opt.StoragePool, err)
+		log.Printf("Unable to get the logging volume [%s] from pool [%s], cause: [%v]", logName, opt.StoragePool, err)
 		// returns some error status
 		return &common.ResourceStatus{
 			Status:      common.Waiting,

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,8 @@ import (
 // CreateServer creates the server that implements the actual controller
 func CreateServer(version, compileTime string) func(port int) error {
 	r := gin.Default()
+	// some generic middleware
+	r.Use()
 	// register the VPC routes
 	r.GET("/vpc/ping", vpc.CreatePingRoute(version, compileTime))
 	r.POST("/vpc/sync", vpc.CreateControllerSyncRoute())


### PR DESCRIPTION
It looks like the method `GetLoggingVolume` (https://github.com/ibm-hyper-protect/k8s-operator-hpcr/blob/main/onprem/logging.go#L98) hangs sometimes (it worked 940 times in our scenario and then failed the 941st time).

The underlying libvirt-go APIs do not have a ways to add a timeout or cancel functionality, so the only way I can think of to handle this is to add a custom timeout and then panic to kill the operator process.

The k8s infrastructure will then try to restart the operator and it will pick up from there.