### PR TITLE
fix: fetch logs directly via SSH and no longer via libvirt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY k8s-operator-hpcr /k8s-operator-hpcr
 
 EXPOSE 8080
 
-ENTRYPOINT [ "/k8s-operator-hpcr" ]
+ENTRYPOINT [ "/k8s-operator-hpcr", "server"]

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -15,16 +15,10 @@
 package cli
 
 import (
-	"log"
 	"strconv"
 	"time"
 
-	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server"
 	c "github.com/urfave/cli/v2"
-)
-
-const (
-	portFlagName = "port"
 )
 
 // CreateApp creates the application that starts the operator
@@ -35,23 +29,10 @@ func CreateApp(version, compiled, commit string) *c.App {
 		Version:  version,
 		Compiled: compiledAt,
 		Name:     "k8s-operator-hpcr",
-		Usage:    "Start HPCR controller",
-		Flags: []c.Flag{
-			&c.IntFlag{
-				Name:    portFlagName,
-				Aliases: []string{"p"},
-				Value:   8080,
-				Usage:   "Port to listen on",
-			},
-		},
-		Action: func(ctx *c.Context) error {
-			port := ctx.Int(portFlagName)
-
-			log.Printf("Starting server [%s] built on [%v] on port [%d] ...", version, compiledAt, port)
-
-			svr := server.CreateServer(version, compiled)
-
-			return svr(port)
+		Usage:    "HPCR controller commands",
+		Commands: []*c.Command{
+			StartServerCommand(version, compiled, commit),
+			DownloadCommand(version, compiled, commit),
 		},
 	}
 }

--- a/cli/download.go
+++ b/cli/download.go
@@ -1,0 +1,66 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package cli
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/ibm-hyper-protect/k8s-operator-hpcr/onprem"
+	c "github.com/urfave/cli/v2"
+)
+
+const (
+	pathFlagName = "path"
+)
+
+// DownloadCommand downloads a volume via ssh from a remote server
+func DownloadCommand(version, compiled, commit string) *c.Command {
+	return &c.Command{
+		Name:        "download",
+		Usage:       "Downloads the content of a volume from a remote server via SSH",
+		Description: "Downloads the content of a volume from a remote server via SSH",
+		Flags: []c.Flag{
+			&c.StringFlag{
+				Name:     pathFlagName,
+				Usage:    "Path of the file to fetch",
+				Required: true,
+				Aliases:  []string{"p"},
+			},
+		},
+		Action: func(ctx *c.Context) error {
+			// path to download
+			path := ctx.String(pathFlagName)
+			// unmarshal the ssh config from stdin
+			dec := json.NewDecoder(os.Stdin)
+			var sshConfig onprem.SSHConfig
+			if err := dec.Decode(&sshConfig); err != nil {
+				return err
+			}
+			// download the volume
+			getVolume := onprem.GetLoggingVolumeViaSSH(&sshConfig)
+			content, err := getVolume(path)
+			if err != nil {
+				return err
+			}
+			// write content to stdout and exit normally
+			if _, err := os.Stdout.WriteString(content); err != nil {
+				return err
+			}
+			// success
+			return nil
+		},
+	}
+}

--- a/cli/server.go
+++ b/cli/server.go
@@ -1,0 +1,56 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package cli
+
+import (
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/ibm-hyper-protect/k8s-operator-hpcr/server"
+	c "github.com/urfave/cli/v2"
+)
+
+const (
+	portFlagName = "port"
+)
+
+// StartServerCommand starts the server implementing the k8s operator
+func StartServerCommand(version, compiled, commit string) *c.Command {
+	compileTime, _ := strconv.ParseInt(compiled, 10, 64)
+	compiledAt := time.UnixMilli(compileTime * 1000)
+	return &c.Command{
+		Name:        "server",
+		Usage:       "Starts HPCR operator",
+		Description: "Starts a server that handles k8s management calls issued by the metacontroller",
+		Flags: []c.Flag{
+			&c.IntFlag{
+				Name:    portFlagName,
+				Aliases: []string{"p"},
+				Value:   8080,
+				Usage:   "Port to listen on",
+			},
+		},
+		Action: func(ctx *c.Context) error {
+			port := ctx.Int(portFlagName)
+
+			log.Printf("Starting server [%s] built on [%v] on port [%d] ...", version, compiledAt, port)
+
+			svr := server.CreateServer(version, compiled)
+
+			return svr(port)
+		},
+	}
+}

--- a/onprem/libvirt.go
+++ b/onprem/libvirt.go
@@ -24,8 +24,9 @@ import (
 
 type LivirtClient struct {
 	io.Closer
-	LibVirt *libvirt.Libvirt
-	Hash    string
+	LibVirt   *libvirt.Libvirt
+	Hash      string
+	SSHConfig *SSHConfig
 }
 
 func (client *LivirtClient) Close() error {
@@ -52,8 +53,9 @@ func CreateLivirtClient(sshConfig *SSHConfig) (*LivirtClient, error) {
 	hash := getHost(sshConfig)
 
 	return &LivirtClient{
-		LibVirt: l,
-		Hash:    hash,
+		LibVirt:   l,
+		Hash:      hash,
+		SSHConfig: sshConfig,
 	}, nil
 }
 

--- a/onprem/logging.go
+++ b/onprem/logging.go
@@ -16,18 +16,25 @@ package onprem
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"time"
 
+	"os/exec"
+
 	CM "github.com/ibm-hyper-protect/k8s-operator-hpcr/common"
+	"golang.org/x/crypto/ssh"
 	"libvirt.org/go/libvirtxml"
 )
 
 const (
 	// some sensible value for the size of the logging volume
 	maxLoggingVolumeSize = uint64(2 * 1024 * 1024)
+	maxDownloadTimeout   = 5 * time.Second
 )
 
 var (
@@ -100,7 +107,7 @@ func GetLoggingVolume(client *LivirtClient) func(storagePool, name string) (stri
 	return func(storagePool, name string) (string, error) {
 		msg := fmt.Sprintf("GetLoggingVolume(%s, %s)", storagePool, name)
 
-		defer CM.PanicAfterTimeout(msg, 5*time.Second)()
+		defer CM.PanicAfterTimeout(msg, maxDownloadTimeout)()
 		defer CM.EntryExit(msg)()
 		// access the pool
 		log.Printf("Looking up storage pool [%s] by name ...", name)
@@ -168,4 +175,145 @@ func VSIFailedToStart(logs []string) bool {
 		}
 	}
 	return false
+}
+
+// GetLoggingVolumeViaSSH retrieves the value of the logging volume via a new and direct SSH connection
+// the HPCR console log is very small by design, so passing it as a string does make sense
+func GetLoggingVolumeViaSSH(config *SSHConfig) func(path string) (string, error) {
+
+	return func(path string) (string, error) {
+		msg := fmt.Sprintf("GetLoggingVolumeViaSSH(%s)", path)
+		defer CM.PanicAfterTimeout(msg, maxDownloadTimeout)()
+		defer CM.EntryExit(msg)()
+
+		origin := getHost(config)
+
+		// detect the username
+		username, err := getUserName(config)
+		if err != nil {
+			return "", err
+		}
+		// host key
+		hostKeyCallback, err := getHostKeyCallback(config)
+		if err != nil {
+			return "", err
+		}
+		// private key
+		signer, err := getPrivateKey(config)
+		if err != nil {
+			log.Printf("Unable to get private key, cause: [%v]", err)
+			return "", err
+		}
+
+		cfg := ssh.ClientConfig{
+			User:            username,
+			HostKeyCallback: hostKeyCallback,
+			Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+			Timeout:         dialTimeout,
+			BannerCallback:  printBanner,
+		}
+
+		sshClient, err := ssh.Dial("tcp", origin, &cfg)
+		if err != nil {
+			log.Printf("Unable to create SSH client, cause: [%v]", err)
+			return "", err
+		}
+		defer sshClient.Close()
+
+		session, err := sshClient.NewSession()
+		if err != nil {
+			log.Printf("Unable to create SSH session, cause: [%v]", err)
+			return "", err
+		}
+		defer session.Close()
+
+		// capture the output of the session
+		var buffer bytes.Buffer
+		session.Stdout = &buffer
+
+		log.Printf("Downloading volume [%s] ...", path)
+		if err := session.Run(fmt.Sprintf("/usr/bin/cat \"%s\"", path)); err != nil {
+			log.Printf("Unable to cat [%s], cause: [%v]", path, err)
+			return "", err
+		}
+		log.Printf("Download of volume [%s] was successful", path)
+
+		return buffer.String(), nil
+	}
+}
+
+// getLoggingVolumeViaSSH retrieves the value of the logging volume by spawning a separate command. The advantage of this approach is
+// that that command can be canceled if it times out
+// the HPCR console log is very small by design, so passing it as a string does make sense
+func getLoggingVolumeViaCommand(ctx context.Context, config *SSHConfig, command string, path string) (string, error) {
+	msg := fmt.Sprintf("getLoggingVolumeViaCommand(%s, %s)", command, path)
+	defer CM.EntryExit(msg)()
+
+	// marshal the ssh config
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		log.Printf("Unable to marshal SSH config, cause: [%v]", err)
+		return "", err
+	}
+
+	// start the command with a proper timeout
+	withTimeout, cancelTimeout := context.WithTimeout(ctx, maxDownloadTimeout)
+	defer cancelTimeout()
+
+	var buffer bytes.Buffer
+
+	cmd := exec.CommandContext(withTimeout, command, "download", "--path", path)
+	cmd.Stdin = bytes.NewReader(configBytes)
+	cmd.Stdout = &buffer
+	cmd.Stderr = os.Stderr
+
+	log.Printf("Executing command [%s] ...", cmd.Path)
+	err = cmd.Run()
+	if err != nil {
+		log.Printf("Error running command [%s], cause: [%v]", cmd.Path, err)
+		return "", err
+	}
+	log.Printf("Execution of command [%s] was successful", cmd.Path)
+
+	return buffer.String(), nil
+}
+
+// GetLoggingVolumeViaSSH retrieves the value of the logging volume by spawning a separate command. The advantage of this approach is
+// that that command can be canceled if it times out
+// the HPCR console log is very small by design, so passing it as a string does make sense
+func GetLoggingVolumeViaCommand(client *LivirtClient) func(storagePool, name string) (string, error) {
+	// config needed for further processing
+	sshConfig := client.SSHConfig
+	conn := client.LibVirt
+
+	return func(storagePool, name string) (string, error) {
+		msg := fmt.Sprintf("GetLoggingVolumeViaCommand(%s, %s)", storagePool, name)
+		defer CM.EntryExit(msg)()
+
+		executable, err := os.Executable()
+		if err != nil {
+			log.Printf("Unable to locate the current executable, cause: [%v]", err)
+			return "", err
+		}
+
+		// access the pool
+		log.Printf("Looking up storage pool [%s] by name ...", name)
+		pool, err := conn.StoragePoolLookupByName(storagePool)
+		if err != nil {
+			log.Printf("Error looking up storage pool [%s] by name, cause: [%v]", storagePool, err)
+			return "", err
+		}
+		log.Printf("Lookup up of storage pool [%s] was successful.", pool.Name)
+
+		// go for the volume
+		log.Printf("Looking up volume [%s] by name in pool [%s] ...", name, pool.Name)
+		vol, err := conn.StorageVolLookupByName(pool, name)
+		if err != nil {
+			log.Printf("Error looking up volume [%s] by name in pool [%s], cause: [%v]", name, pool.Name, err)
+			return "", err
+		}
+		log.Printf("Lookup up of volume [%s] by name in pool [%s] was successful.", vol.Name, pool.Name)
+
+		return getLoggingVolumeViaCommand(context.Background(), sshConfig, executable, vol.Key)
+	}
 }

--- a/onprem/logging_test.go
+++ b/onprem/logging_test.go
@@ -84,3 +84,29 @@ func TestPartitionFailedStartup(t *testing.T) {
 	assert.NotEmpty(t, failure)
 	assert.NotEmpty(t, success)
 }
+
+// func TestDirectVolumeDownload(t *testing.T) {
+// 	config, err := defaultSSHConfig("../.env")
+// 	if err != nil {
+// 		t.SkipNow()
+// 	}
+
+// 	getVolume := GetLoggingVolumeViaSSH(config)
+
+// 	data, err := getVolume("/var/lib/libvirt/images/console-e140b66c-be72-4d49-9348-b0f4b658b073.log")
+// 	require.NoError(t, err)
+
+// 	fmt.Println(data)
+// }
+
+// func TestGetLoggingViaCommand(t *testing.T) {
+// 	config, err := defaultSSHConfig("../.env")
+// 	if err != nil {
+// 		t.SkipNow()
+// 	}
+
+// 	data, err := getLoggingVolumeViaCommand(context.Background(), config, "../k8s-operator-hpcr.exe", "/var/lib/libvirt/images/console-e140b66c-be72-4d49-9348-b0f4b658b073.log")
+// 	require.NoError(t, err)
+
+// 	fmt.Println(data)
+// }

--- a/onprem/ssh_test.go
+++ b/onprem/ssh_test.go
@@ -15,8 +15,11 @@
 package onprem
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"testing"
 
 	libvirt "github.com/digitalocean/go-libvirt"
@@ -82,5 +85,27 @@ func TestSerializeToMap(t *testing.T) {
 	deser := GetSSHConfigFromEnvMap(env)
 
 	assert.Equal(t, config, deser)
+
+}
+
+func TestMarshalSSHConfig(t *testing.T) {
+	config, err := defaultSSHConfig("../.env")
+	if err != nil {
+		t.SkipNow()
+	}
+	// target
+	dstPath := "../build"
+	err = os.MkdirAll(dstPath, os.ModePerm)
+	require.NoError(t, err)
+	// marshal
+	dstFile := filepath.Join(dstPath, "sshconfig.json")
+	dst, err := os.Create(dstFile)
+	require.NoError(t, err)
+	defer dst.Close()
+
+	// marshal
+	enc := json.NewEncoder(dst)
+	err = enc.Encode(config)
+	require.NoError(t, err)
 
 }

--- a/server/onprem/actions.go
+++ b/server/onprem/actions.go
@@ -44,7 +44,8 @@ func createInstanceRunningAction(client *onprem.LivirtClient, inst *libvirtxml.D
 	defer CM.PanicAfterTimeout(msg, 5*time.Second)()
 	defer CM.EntryExit(msg)()
 
-	getLoggingVolume := onprem.GetLoggingVolume(client)
+	// getLoggingVolume := onprem.GetLoggingVolume(client)
+	getLoggingVolume := onprem.GetLoggingVolumeViaCommand(client)
 	getLeases := onprem.GetDCHPLeases(client)
 
 	// getIPAddresses determines the IP Addresses for the instance by checking for a all leases


### PR DESCRIPTION
This PR circumvents the problem that the libvirt method `StorageVolDownload` hangs from time to time and that it cannot be canceled nor does it support a timeout. 

The new approach to access the logs is to fetch them directly via SSH and no longer via libvirt. Furthermore access to the logs via SSH is done via a separate process, so the actual operator can kill this process in case of a timeout. This is realized by designing the binary for the operator as a multi-command cli. The `server` command starts the server. The `download` command downloads the desired log, so when the operator in `server` mode tries to access the log, it will call its own binary in a new process with the `download` command. The path of the desired log file is passed as a command line parameter, the required ssh config is passed in via stdin to the command.

The price for this approach is that downloading of the logs takes much longer, around 1s instead of 100ms, but it's better than having a hang in the operator, which requires to kill and restart the process of the operator itself.