### PR TITLE
fix: add support for stable mac address and stable uuid

### DIFF
--- a/onprem/domain.go
+++ b/onprem/domain.go
@@ -76,7 +76,7 @@ func getCanonicalMachineName(caps *libvirtxml.Caps, arch string, virttype string
 		}
 	}
 
-	return "", fmt.Errorf("Cannot find machine type %s for %s/%s in %v", targetmachine, virttype, arch, caps)
+	return "", fmt.Errorf("cannot find machine type %s for %s/%s in %v", targetmachine, virttype, arch, caps)
 }
 
 func getHostCapabilities(virConn *libvirt.Libvirt) (*libvirtxml.Caps, error) {
@@ -168,7 +168,7 @@ func createDefaultDomainDef(client *LivirtClient) (*libvirtxml.Domain, error) {
 					},
 					Source: &libvirtxml.DomainInterfaceSource{
 						Network: &libvirtxml.DomainInterfaceSourceNetwork{
-							Network: "default",
+							Network: DefaultNetwork,
 						},
 					},
 					Driver: &libvirtxml.DomainInterfaceDriver{

--- a/onprem/mac.go
+++ b/onprem/mac.go
@@ -1,0 +1,62 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Ache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package onprem
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// createMacAddressFromBytes creates a local, unicast mac address
+func createMacAddressFromBytes(data [6]byte) string {
+	// lsb, make sure to identify as a local address and set the multicast bit to zero (see https://en.wikipedia.org/wiki/MAC_address)
+	lsb := (data[0] & 0xfe) | 0x02
+	return fmt.Sprintf("%02X:%02X:%02X:%02X:%02X:%02X", lsb, data[1], data[2], data[3], data[4], data[5])
+}
+
+// CreateMacAddressFromUUID creates a mac address from the first 6 bytes of the UUID
+func CreateMacAddressFromUUID(uid uuid.UUID) string {
+	// need 6 bytes for the address
+	mac := [6]byte{}
+	copy(mac[:], uid[:])
+	// produce a valid mac address
+	return createMacAddressFromBytes(mac)
+}
+
+// constructs a hash value for the string and produces a mac address from that
+func CreateMacAddressFromHash(data string) string {
+	h := sha256.New()
+	h.Write([]byte(data))
+	// need 6 bytes for the address
+	mac := [6]byte{}
+	copy(mac[:], h.Sum(nil))
+	// produce a valid mac address
+	return createMacAddressFromBytes(mac)
+}
+
+// CreateMacAddressFromMaybeUUID tries to parse the UUID from a string, then generate a MAC address from it
+// if the string could not be decoded, create a MAC from a hash instead
+func CreateMacAddressFromMaybeUUID(maybeuuid string) string {
+	// try to parse the uuid and use it if possible
+	uid, err := uuid.Parse(maybeuuid)
+	if err != nil {
+		// fallback to a hash
+		return CreateMacAddressFromHash(maybeuuid)
+	}
+	// from UUID
+	return CreateMacAddressFromUUID(uid)
+}

--- a/onprem/mac_test.go
+++ b/onprem/mac_test.go
@@ -1,0 +1,45 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package onprem
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMacAddress(t *testing.T) {
+
+	mac := CreateMacAddressFromHash("This is some input")
+	addr, err := net.ParseMAC(mac)
+
+	require.NoError(t, err)
+	assert.Equal(t, addr[:], net.HardwareAddr{0xb6, 0x8c, 0xca, 0xe7, 0x6f, 0xf1})
+}
+
+func TestMacAddressFromUUID(t *testing.T) {
+
+	uid, err := uuid.Parse("d3414e67-a26f-4791-96f1-cd842c15346c")
+	require.NoError(t, err)
+
+	mac := CreateMacAddressFromUUID(uid)
+	addr, err := net.ParseMAC(mac)
+
+	require.NoError(t, err)
+	assert.Equal(t, addr[:], net.HardwareAddr{0xd2, 0x41, 0x4e, 0x67, 0xa2, 0x6f})
+}

--- a/onprem/machineid.go
+++ b/onprem/machineid.go
@@ -1,0 +1,48 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Ache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package onprem
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/google/uuid"
+)
+
+// CreateMachineIdFromUUID creates a machineID from a UUID
+func CreateMachineIdFromUUID(uid uuid.UUID) string {
+	return hex.EncodeToString(uid[0:16])
+}
+
+// CreateMachineIdFromHash creates a hash of the input and then a machine ID
+func CreateMachineIdFromHash(data string) string {
+	h := sha256.New()
+	h.Write([]byte(data))
+	// convert to a machine ID
+	return hex.EncodeToString(h.Sum(nil)[0:16])
+}
+
+// CreateMachineIdFromMaybeUUID tries to parse the UUID from a string, then generate a machine ID from it
+// if the string could not be decoded, create a machine ID from a hash instead
+func CreateMachineIdFromMaybeUUID(maybeuuid string) string {
+	// try to parse the uuid and use it if possible
+	uid, err := uuid.Parse(maybeuuid)
+	if err != nil {
+		// fallback to a hash
+		return CreateMachineIdFromHash(maybeuuid)
+	}
+	// from UUID
+	return CreateMachineIdFromUUID(uid)
+}

--- a/onprem/machineid_test.go
+++ b/onprem/machineid_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package datasource
+
+package onprem
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMachineId(t *testing.T) {
+
+	machineId := CreateMachineIdFromHash("This is some input")
+	assert.Len(t, machineId, 32)
+}
+
+func TestMachineIdFromUUID(t *testing.T) {
+
+	uid, err := uuid.Parse("d3414e67-a26f-4791-96f1-cd842c15346c")
+	require.NoError(t, err)
+
+	machineId := CreateMachineIdFromUUID(uid)
+
+	assert.Len(t, machineId, 32)
+}

--- a/samples/contracts/busybox/compose/docker-compose.yaml
+++ b/samples/contracts/busybox/compose/docker-compose.yaml
@@ -4,4 +4,7 @@ services:
   busybox:
     image: docker.io/library/busybox@sha256:2376a0c12759aa1214ba83e771ff252c7b1663216b192fbe5e0fb364e952f85c
     command: |
-      echo "Hello from busybox"
+      sh /var/lib/busybox/run.sh
+    volumes:
+      - ./run.sh:/var/lib/busybox/run.sh:ro
+      - /etc/machine-id:/var/lib/busybox/machine-id:ro      

--- a/samples/contracts/busybox/compose/run.sh
+++ b/samples/contracts/busybox/compose/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+echo "Hello from busybox, machine-id: $(cat /var/lib/busybox/machine-id)!"


### PR DESCRIPTION
Addresses https://github.com/ibm-hyper-protect/k8s-operator-hpcr/issues/105

In this implementation we create both stable mac addresses as well as stable UUIDs for the libvirt instances. 

The k8s system assigns unique UUIDs to each custom resource, including the custom resource for the VSI. This PR uses this UUID for the following:
- as both the name and (new) the UUID of the KVM instance
- if no network is configured explicitly, the operator attaches the default network. In this case the PR will create a (reproducible) mac address based on the UUID of the custom resource. 
- if one or more networks are configured this PR will create a (reproducible) mac address based on a hash over the UUID of the instance and the name of the network to attach to

All mac addresses are marked as local (bit1 set to 1) and as unicast (bit0 set to 0), see https://en.wikipedia.org/wiki/MAC_address